### PR TITLE
Fix validation of audio and video content, add track element

### DIFF
--- a/library/HTMLPurifier/ChildDef/Media.php
+++ b/library/HTMLPurifier/ChildDef/Media.php
@@ -1,0 +1,94 @@
+<?php
+
+class HTMLPurifier_ChildDef_Media extends HTMLPurifier_ChildDef
+{
+    public $type = 'media';
+
+    public $elements = array(
+        'source' => true,
+        'track'  => true,
+    );
+
+    protected $allowedElements;
+
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return array
+     */
+    public function getAllowedElements($config)
+    {
+        if (null === $this->allowedElements) {
+            // Add Flow content to allowed elements to prevent MakeWellFormed
+            // strategy moving them outside details element
+            $def = $config->getHTMLDefinition();
+
+            $this->allowedElements = array_merge(
+                $def->info_content_sets['Flow'],
+                $this->elements
+            );
+            unset(
+                $this->allowedElements['audio'],
+                $this->allowedElements['video']
+            );
+        }
+        return $this->allowedElements;
+    }
+
+    /**
+     * @param array $children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($children, $config, $context)
+    {
+        // Content model:
+        // If the element has a src attribute: zero or more track elements,
+        // then transparent, but with no media element descendants.
+        // If the element does not have a src attribute: zero or more source
+        // elements, then zero or more track elements, then transparent, but
+        // with no media element descendants.
+
+        $allowSource = isset($config->getHTMLDefinition()->info['source']);
+        $allowTrack = isset($config->getHTMLDefinition()->info['track']);
+
+        $sources = array();
+        $tracks = array();
+        $content = array();
+
+        foreach ($children as $node) {
+            switch ($node->name) {
+                case 'source':
+                    if ($allowSource) {
+                        $sources[] = $node;
+                    }
+                    break;
+
+                case 'track':
+                    if ($allowTrack) {
+                        $tracks[] = $node;
+                    }
+                    break;
+
+                default:
+                    $content[] = $node;
+                    break;
+            }
+        }
+
+        $currentNode = $context->get('CurrentNode');
+        $hasSrcAttr = $currentNode instanceof HTMLPurifier_Node_Element && isset($currentNode->attr['src']);
+
+        if ($hasSrcAttr) {
+            $result = array_merge($tracks, $content);
+        } else {
+            $result = array_merge($sources, $tracks, $content);
+        }
+
+        if (empty($result) && !$hasSrcAttr) {
+            return false;
+        }
+
+        return $result;
+    }
+}

--- a/library/HTMLPurifier/HTML5Definition.php
+++ b/library/HTMLPurifier/HTML5Definition.php
@@ -31,8 +31,10 @@ class HTMLPurifier_HTML5Definition
         $def->addElement('figure', 'Block', 'Flow', 'Common');
         $def->addElement('figcaption', 'Inline', 'Flow', 'Common');
 
-        // http://developers.whatwg.org/the-video-element.html#the-video-element
-        $def->addElement('video', 'Block', 'Flow', 'Common', array(
+        $mediaContent = new HTMLPurifier_ChildDef_Media();
+
+        // https://html.spec.whatwg.org/dev/media.html#the-video-element
+        $def->addElement('video', 'Block', $mediaContent, 'Common', array(
             'controls' => 'Bool',
             'height'   => 'Length',
             'poster'   => 'URI',
@@ -41,20 +43,29 @@ class HTMLPurifier_HTML5Definition
             'width'    => 'Length',
         ));
 
-        // http://developers.whatwg.org/the-video-element.html#the-audio-element
-        $def->addElement('audio', 'Block', 'Flow', 'Common', array(
+        // https://html.spec.whatwg.org/dev/media.html#the-audio-element
+        $def->addElement('audio', 'Block', $mediaContent, 'Common', array(
             'controls' => 'Bool',
             'preload'  => 'Enum#auto,metadata,none',
             'src'      => 'URI',
         ));
 
         // https://html.spec.whatwg.org/dev/embedded-content.html#the-source-element
-        $def->addElement('source', 'Block', 'Empty', 'Common', array(
+        $def->addElement('source', false, 'Empty', 'Common', array(
             'media'  => 'Text',
             'sizes'  => 'Text',
             'src'    => 'URI',
             'srcset' => 'Text',
             'type'   => 'Text',
+        ));
+
+        // https://html.spec.whatwg.org/dev/media.html#the-track-element
+        $def->addElement('track', false, 'Empty', 'Common', array(
+            'kind'    => 'Enum#captions,chapters,descriptions,metadata,subtitles',
+            'src'     => 'URI',
+            'srclang' => 'Text',
+            'label'   => 'Text',
+            'default' => 'Bool',
         ));
 
         // https://html.spec.whatwg.org/dev/embedded-content.html#the-picture-element

--- a/tests/HTMLPurifier/HTML5DefinitionTest.php
+++ b/tests/HTMLPurifier/HTML5DefinitionTest.php
@@ -62,7 +62,11 @@ class HTMLPurifier_HTML5DefinitionTest extends PHPUnit_Framework_TestCase
             array('<audio controls><source src="audio.ogg" type="audio/ogg"></audio>'),
             array('<audio controls src="audio.ogg"></audio>'),
             array('<audio controls><source src="audio.ogg" type="audio/ogg">Your browser does not support audio</audio>'),
-            array('<audio controls src="audio.ogg">Your browser does not support audio</audio>'),
+            array('<audio controls><source src="audio.ogg" type="audio/ogg"><track kind="subtitles" src="subtitles.vtt">Your browser does not support audio</audio>'),
+            array('<audio controls><track kind="subtitles" src="subtitles.vtt">Your browser does not support audio</audio>'),
+            array('<audio src="audio.ogg">Your browser does not support audio</audio>'),
+            array('<audio src="audio.ogg"><p>Your browser does not support audio</p></audio>'),
+            array('<audio src="audio.ogg"><track kind="subtitles" src="subtitles.vtt"></audio>'),
         );
     }
 
@@ -83,6 +87,13 @@ class HTMLPurifier_HTML5DefinitionTest extends PHPUnit_Framework_TestCase
             array('<video width="400" height="400" poster="poster.png" src="video.mp4"></video>'),
             array('<video width="400" height="400" poster="poster.png"><source src="video.mp4" type="video/mp4">Your browser does not support video</video>'),
             array('<video width="400" height="400" poster="poster.png" src="video.mp4">Your browser does not support video</video>'),
+            array('<video src="video.mp4"></video>'),
+            array('<video src="video.mp4">Your browser does not support video</video>'),
+            array('<video src="video.mp4"><p>Your browser does not support video</p></video>'),
+            array('<video src="video.mp4"><track kind="subtitles" src="subtitles.vtt"></video>'),
+            array('<video><source src="video.mp4" type="video/mp4"></video>'),
+            array('<video><track kind="subtitles" src="subtitles.vtt"></video>'),
+            array('<video><source src="video.mp4" type="video/mp4"><track kind="subtitles" src="subtitles.vtt"></video>'),
         );
     }
 


### PR DESCRIPTION
Existing implementation of `audio` and `video` elements wasn't following the content model spec - it allowed any elements, with no special treatment of `source` elements.

Additionally, `source` elements were allowed anywhere, but should only appear inside `audio`, `video` and `picture` elements.