### PR TITLE
Fix a element: allow flow content, add html5 attrs

### DIFF
--- a/library/HTMLPurifier/HTML5Definition.php
+++ b/library/HTMLPurifier/HTML5Definition.php
@@ -87,6 +87,15 @@ class HTMLPurifier_HTML5Definition
         $time = $def->addElement('time', 'Inline', 'Inline', 'Common', array('datetime' => 'Text', 'pubdate' => 'Bool'));
         $time->excludes = array('time' => true);
 
+        // https://html.spec.whatwg.org/dev/text-level-semantics.html#the-a-element
+        $def->addElement('a', 'Flow', 'Flow', 'Common', array(
+            'download' => 'Text',
+            'hreflang' => 'Text',
+            'rel'      => 'Text',
+            'target'   => new HTMLPurifier_AttrDef_HTML_FrameTarget(),
+            'type'     => 'Text',
+        ));
+
         // IMG
         $def->addAttribute('img', 'srcset', 'Text');
 

--- a/tests/HTMLPurifier/HTML5DefinitionTest.php
+++ b/tests/HTMLPurifier/HTML5DefinitionTest.php
@@ -36,6 +36,43 @@ class HTMLPurifier_HTML5DefinitionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($input, $output);
     }
 
+    /**
+     * Data provider for {@link testAnchor()}
+     * @return array
+     */
+    public function anchorInput()
+    {
+        return array(
+            array(
+                '<a href="foo" type="video/mp4" hreflang="en"><h1>Heading</h1><p>Description</p></a>',
+            ),
+            array(
+                '<a href="foo" target="_blank" rel="nofollow">Visit</a>',
+                '<a href="foo" target="_blank" rel="nofollow noreferrer noopener">Visit</a>',
+            ),
+            array(
+                '<a href="foo" download>Download</a>',
+                '<a href="foo" download="">Download</a>',
+            ),
+            array(
+                '<a href="foo" download="bar">Download</a>',
+            ),
+        );
+    }
+
+    /**
+     * @param string $input
+     * @param string $expectedOutput OPTIONAL
+     * @dataProvider anchorInput
+     */
+    public function testAnchor($input, $expectedOutput = null)
+    {
+        $output = $this->getPurifier(array(
+            'Attr.AllowedFrameTargets' => array('_blank'),
+        ))->purify($input);
+        $this->assertEquals($expectedOutput !== null ? $expectedOutput : $input, $output);
+    }
+
     public function figureInput()
     {
         return array(


### PR DESCRIPTION
In HTML5 `a` element can contain either flow content (excluding interactive content) or phrasing content.

Related to ezyang/htmlpurifier#159. 