### PR TITLE
Fix content model definition of <figure> element

### DIFF
--- a/library/HTMLPurifier/ChildDef/Figure.php
+++ b/library/HTMLPurifier/ChildDef/Figure.php
@@ -1,0 +1,84 @@
+<?php
+
+class HTMLPurifier_ChildDef_Figure extends HTMLPurifier_ChildDef
+{
+    public $type = 'figure';
+
+    public $elements = array(
+        'figcaption' => true,
+    );
+
+    protected $allowedElements;
+
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return array
+     */
+    public function getAllowedElements($config)
+    {
+        if (null === $this->allowedElements) {
+            // Add Flow content to allowed elements to prevent MakeWellFormed
+            // strategy moving them outside 'figure' element
+            $def = $config->getHTMLDefinition();
+
+            $this->allowedElements = array_merge(
+                $def->info_content_sets['Flow'],
+                $this->elements
+            );
+        }
+        return $this->allowedElements;
+    }
+
+    /**
+     * @param array $children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($children, $config, $context)
+    {
+        $allowFigcaption = isset($config->getHTMLDefinition()->info['figcaption']);
+        $hasFigcaption = false;
+        $figcaptionPos = -1;
+
+        $result = array();
+
+        // Content model:
+        // Either: one figcaption element followed by flow content.
+        // Or: flow content followed by one figcaption element.
+        // Or: flow content.
+
+        // Scan through children, accept at most one figcaption. If additional
+        // figcaption appears replace it with div
+        foreach ($children as $node) {
+            if ($node->name === 'figcaption') {
+                if ($allowFigcaption && !$hasFigcaption) {
+                    $hasFigcaption = true;
+                    $figcaptionPos = count($result);
+                    $result[] = $node;
+                    continue;
+                }
+
+                $div = new HTMLPurifier_Node_Element('div', $node->attr);
+                $div->children = $node->children;
+                $result[] = $div;
+                continue;
+            }
+
+            // Figcaption must be a first or last child of a figure element.
+            // If it's not first, then we ignore all siblings that come after.
+            if ($hasFigcaption && $figcaptionPos > 0) {
+                break;
+            }
+
+            $result[] = $node;
+        }
+
+        // if there are no children remove parent node
+        if (empty($result)) {
+            return false;
+        }
+
+        return $result;
+    }
+}

--- a/library/HTMLPurifier/HTML5Definition.php
+++ b/library/HTMLPurifier/HTML5Definition.php
@@ -27,9 +27,9 @@ class HTMLPurifier_HTML5Definition
         $def->addElement('address', 'Block', 'Flow', 'Common');
         $def->addElement('hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common');
 
-        // http://developers.whatwg.org/grouping-content.html
-        $def->addElement('figure', 'Block', 'Flow', 'Common');
-        $def->addElement('figcaption', 'Inline', 'Flow', 'Common');
+        // https://html.spec.whatwg.org/dev/grouping-content.html#the-figure-element
+        $def->addElement('figure', 'Block', new HTMLPurifier_ChildDef_Figure(), 'Common');
+        $def->addElement('figcaption', false, 'Flow', 'Common');
 
         $mediaContent = new HTMLPurifier_ChildDef_Media();
 

--- a/tests/HTMLPurifier/HTML5DefinitionTest.php
+++ b/tests/HTMLPurifier/HTML5DefinitionTest.php
@@ -76,21 +76,36 @@ class HTMLPurifier_HTML5DefinitionTest extends PHPUnit_Framework_TestCase
     public function figureInput()
     {
         return array(
-            array('<figure><img src="image.png" alt="An awesome picture"><figcaption>Fig1. Image</figcaption></figure>'),
-            array('<figure><p>Something</p><figcaption><cite>Someone</cite></figcaption><p>Something</p></figure>'),
-            array('<figure><figcaption><cite>Someone</cite></figcaption>Something</figure>'),
-            array('<figure></figure>'),
+            array(
+                '<figure><img src="image.png" alt="An awesome picture"><figcaption>Fig.1 Image</figcaption></figure>',
+            ),
+            array(
+                '<figure><figcaption><cite>Someone</cite></figcaption>Something</figure>',
+            ),
+            array(
+                '<figure><p>Something</p><figcaption><cite>Someone</cite></figcaption><p>Something</p></figure>',
+                '<figure><p>Something</p><figcaption><cite>Someone</cite></figcaption></figure>',
+            ),
+            array(
+                '<figure><figcaption>Foo</figcaption><figcaption>Bar</figcaption>Baz</figure>',
+                '<figure><figcaption>Foo</figcaption><div>Bar</div>Baz</figure>',
+            ),
+            array(
+                '<figure></figure>',
+                '',
+            ),
         );
     }
 
     /**
+     * @param string $input
+     * @param string $expectedOutput OPTIONAL
      * @dataProvider figureInput
      */
-    public function testFigure($input)
+    public function testFigure($input, $expectedOutput = null)
     {
         $output = $this->getPurifier()->purify($input);
-
-        $this->assertEquals($input, $output);
+        $this->assertEquals($expectedOutput !== null ? $expectedOutput : $input, $output);
     }
 
     public function audioInput()


### PR DESCRIPTION
Previous definition of `<figure>` element didn't follow [the spec](https://html.spec.whatwg.org/dev/grouping-content.html#the-figure-element). It also allowed `<figcaption>` elements outside `<figure>`.