### PR TITLE
Fix content category of <audio> and <video>

### DIFF
--- a/library/HTMLPurifier/HTML5Config.php
+++ b/library/HTMLPurifier/HTML5Config.php
@@ -2,7 +2,7 @@
 
 class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 {
-    const REVISION = 2018060601;
+    const REVISION = 2018060701;
 
     /**
      * @param  string|array|HTMLPurifier_Config $config

--- a/library/HTMLPurifier/HTML5Definition.php
+++ b/library/HTMLPurifier/HTML5Definition.php
@@ -34,7 +34,7 @@ class HTMLPurifier_HTML5Definition
         $mediaContent = new HTMLPurifier_ChildDef_Media();
 
         // https://html.spec.whatwg.org/dev/media.html#the-video-element
-        $def->addElement('video', 'Block', $mediaContent, 'Common', array(
+        $def->addElement('video', 'Flow', $mediaContent, 'Common', array(
             'controls' => 'Bool',
             'height'   => 'Length',
             'poster'   => 'URI',
@@ -42,13 +42,15 @@ class HTMLPurifier_HTML5Definition
             'src'      => 'URI',
             'width'    => 'Length',
         ));
+        $def->getAnonymousModule()->addElementToContentSet('video', 'Inline');
 
         // https://html.spec.whatwg.org/dev/media.html#the-audio-element
-        $def->addElement('audio', 'Block', $mediaContent, 'Common', array(
+        $def->addElement('audio', 'Flow', $mediaContent, 'Common', array(
             'controls' => 'Bool',
             'preload'  => 'Enum#auto,metadata,none',
             'src'      => 'URI',
         ));
+        $def->getAnonymousModule()->addElementToContentSet('audio', 'Inline');
 
         // https://html.spec.whatwg.org/dev/embedded-content.html#the-source-element
         $def->addElement('source', false, 'Empty', 'Common', array(

--- a/tests/HTMLPurifier/HTML5DefinitionTest.php
+++ b/tests/HTMLPurifier/HTML5DefinitionTest.php
@@ -123,10 +123,15 @@ class HTMLPurifier_HTML5DefinitionTest extends PHPUnit_Framework_TestCase
             array('<audio src="audio.ogg">Your browser does not support audio</audio>'),
             array('<audio src="audio.ogg"><p>Your browser does not support audio</p></audio>'),
             array('<audio src="audio.ogg"><track kind="subtitles" src="subtitles.vtt"></audio>'),
+            array(
+                // <audio> is a phrasing content element
+                '<strong><audio controls><source type="audio/mp3" src="audio.mp3"></audio></strong>',
+            ),
         );
     }
 
     /**
+     * @param string $input
      * @dataProvider audioInput
      */
     public function testAudio($input)
@@ -150,10 +155,15 @@ class HTMLPurifier_HTML5DefinitionTest extends PHPUnit_Framework_TestCase
             array('<video><source src="video.mp4" type="video/mp4"></video>'),
             array('<video><track kind="subtitles" src="subtitles.vtt"></video>'),
             array('<video><source src="video.mp4" type="video/mp4"><track kind="subtitles" src="subtitles.vtt"></video>'),
+            array(
+                // <video> is a phrasing content element
+                '<em><video><source src="video.mp4" type="video/mp4"></video></em>',
+            ),
         );
     }
 
     /**
+     * @param string $input
      * @dataProvider videoInput
      */
     public function testVideo($input)


### PR DESCRIPTION
Related to #17.

`<audio>` and `<video>` are phrasing content elements. And as such, according to https://www.w3.org/TR/html5-diff/#content-model, should behave both like inline and flow elements.

> Phrasing content, e.g. span, img, text. This is roughly like HTML4's "inline". Elements that are phrasing content are also flow content.
