### PR TITLE
Remove <menu> and <menuitem> elements from todo list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ article, aside, audio, details, figcaption, figure, footer, header, hgroup, main
 
 ### Elements not (yet) supported
 
-dialog, menu, menuitem
+dialog
 
 ## License
 


### PR DESCRIPTION
`<menu>` and `<menuitem>` elements introduced in [HTML 5.1](https://www.w3.org/TR/html51/interactive-elements.html#the-menu-element) were [removed from the HTML 5.2 spec](https://www.w3.org/TR/html52/obsolete.html#non-conforming-features). No need to keep them on the todo list.