### PR TITLE
Add HTML5 Scripting module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ezyang/htmlpurifier": "^4.7"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.7",
+        "phpunit/phpunit": ">=4.7 <8.0",
         "php-coveralls/php-coveralls": "^1.1|^2.1"
     },
     "autoload": {

--- a/library/HTMLPurifier/AttrTransform/HTML5/Script.php
+++ b/library/HTMLPurifier/AttrTransform/HTML5/Script.php
@@ -1,0 +1,23 @@
+<?php
+
+class HTMLPurifier_AttrTransform_HTML5_Script extends HTMLPurifier_AttrTransform
+{
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        // If 'src' is specified, it must be a valid non-empty URL potentially
+        // surrounded by spaces.
+        // If 'src' is present, regardless it's empty or not, script text is
+        // ignored by browsers.
+        if (isset($attr['src']) && trim($attr['src']) === '') {
+            unset($attr['src']);
+        }
+
+        return $attr;
+    }
+}

--- a/library/HTMLPurifier/ChildDef/HTML5.php
+++ b/library/HTMLPurifier/ChildDef/HTML5.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Utility class for HTML5 ChildDef classes
+ */
+abstract class HTMLPurifier_ChildDef_HTML5 extends HTMLPurifier_ChildDef
+{
+    /**
+     * Helper method for recursive elements removal
+     *
+     * @param HTMLPurifier_Node[] $children
+     * @param string|string[] $elements
+     * @return HTMLPurifier_Node[]
+     */
+    public static function filterOutElements($children, $elements)
+    {
+        if (!is_array($elements)) {
+            $elements = array($elements);
+        }
+        $result = array();
+        foreach ((array) $children as $child) {
+            if ($child instanceof HTMLPurifier_Node_Element) {
+                $filteredChildren = self::filterOutElements($child->children, $elements);
+                if (in_array($child->name, $elements, true)) {
+                    // don't add removed element, only its children
+                    foreach ($filteredChildren as $c) {
+                        $result[] = $c;
+                    }
+                    continue;
+                }
+                $child->children = $filteredChildren;
+            }
+            $result[] = $child;
+        }
+        return $result;
+    }
+}

--- a/library/HTMLPurifier/ChildDef/HTML5/Noscript.php
+++ b/library/HTMLPurifier/ChildDef/HTML5/Noscript.php
@@ -1,0 +1,46 @@
+<?php
+
+class HTMLPurifier_ChildDef_HTML5_Noscript extends HTMLPurifier_ChildDef
+{
+    public $type = 'noscript';
+
+    protected $allowedElements;
+
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return array
+     */
+    public function getAllowedElements($config)
+    {
+        if ($this->allowedElements === null) {
+            $def = $config->getHTMLDefinition();
+
+            // According to spec <noscript> cannot be nested.
+            // Match browsers' behavior by autoclosing tag whenever a child
+            // <noscript> is encountered.
+            $this->allowedElements = $def->info_content_sets['Flow'];
+            unset($this->allowedElements['noscript']);
+        }
+        return $this->allowedElements;
+    }
+
+    /**
+     * @param HTMLPurifier_Node[] $children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Node[]|bool
+     */
+    public function validateChildren($children, $config, $context)
+    {
+        // Permitted content: flow content or phrasing content, but
+        // no <noscript> element must be among its descendants.
+        $children = HTMLPurifier_ChildDef_HTML5::filterOutElements($children, 'noscript');
+
+        // Remove empty <noscript> element
+        if (empty($children)) {
+            return false;
+        }
+
+        return $children;
+    }
+}

--- a/library/HTMLPurifier/ChildDef/HTML5/Script.php
+++ b/library/HTMLPurifier/ChildDef/HTML5/Script.php
@@ -1,0 +1,81 @@
+<?php
+
+class HTMLPurifier_ChildDef_HTML5_Script extends HTMLPurifier_ChildDef
+{
+    public $type = 'script';
+
+    /**
+     * Whether children (text contents) are allowed
+     * @var bool
+     */
+    public $allow_children = true;
+
+    /**
+     * @param HTMLPurifier_Node[] $children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Node[]|bool
+     */
+    public function validateChildren($children, $config, $context)
+    {
+        $node = $context->exists('CurrentNode')
+            ? $context->get('CurrentNode')
+            : null;
+
+        // Content model:
+        //   If there is no src attribute, depends on the value of the type
+        //   attribute, but must match script content restrictions.
+        //   If there is a src attribute, the element must be either empty
+        //   or contain only script documentation that also matches script
+        //   content restrictions.
+        // https://html.spec.whatwg.org/multipage/scripting.html#the-script-element
+
+        if ($node instanceof HTMLPurifier_Node_Element) {
+            // must validate src attribute here, because children validation is
+            // executed before attribute validation
+
+            // This part I don't like, but currently it's unavoidable because
+            // of how HTMLPurifier works internally. Attribute transformations
+            // and validations are done after children validation. So there is
+            // no way of knowing whether src attribute is valid other than
+            // do the validation here as well.
+            $src = $this->getSrc($node, $config, $context);
+
+            if (strlen($src)) {
+                return array();
+            }
+
+            // Remove <script> if there is no 'src' attribute and no children
+            // or if children are explicitly forbidden
+            if (empty($children) || !$this->allow_children) {
+                return false;
+            }
+        }
+
+        return $this->allow_children ? true : array();
+    }
+
+    /**
+     * @param HTMLPurifier_Node_Element $element
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
+     */
+    protected function getSrc(HTMLPurifier_Node_Element $element, HTMLPurifier_Config $config, HTMLPurifier_Context $context)
+    {
+        $src = isset($element->attr['src']) ? trim($element->attr['src']) : '';
+
+        if (strlen($src)) {
+            $info = $config->getHTMLDefinition()->info['script'];
+            if (isset($info->attr['src'])) {
+                /** @var HTMLPurifier_AttrDef $srcAttrDef */
+                $srcAttrDef = $info->attr['src'];
+
+                $result = $srcAttrDef->validate($src, $config, $context);
+                $src = $result === true ? $src : $result;
+            }
+        }
+
+        return $src;
+    }
+}

--- a/library/HTMLPurifier/HTML5Config.php
+++ b/library/HTMLPurifier/HTML5Config.php
@@ -2,7 +2,7 @@
 
 class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 {
-    const REVISION = 2018091601;
+    const REVISION = 2019041001;
 
     /**
      * @param  string|array|HTMLPurifier_Config $config
@@ -75,6 +75,7 @@ class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 
         $this->set('HTML.Doctype', 'HTML5');
         $this->set('Attr.ID.HTML5', true);
+        $this->set('Output.CommentScriptContents', false);
     }
 
     public function getDefinition($type, $raw = false, $optimized = false)

--- a/library/HTMLPurifier/HTML5Definition.php
+++ b/library/HTMLPurifier/HTML5Definition.php
@@ -16,7 +16,7 @@ class HTMLPurifier_HTML5Definition
             'Presentation', 'Edit', 'Bdo', 'Tables', 'Image',
             'StyleAttribute',
             // Unsafe:
-            'Scripting', 'Object', 'Forms',
+            'HTML5_Scripting', 'Object', 'Forms',
             // Sorta legacy, but present in strict:
             'Name',
         );
@@ -30,6 +30,13 @@ class HTMLPurifier_HTML5Definition
             array('Tidy_Transitional', 'Tidy_Proprietary'),
             array()
         );
+
+        // override default SafeScripting module
+        // Because how the built-in SafeScripting module is enabled in ModuleManager,
+        // to override it exactly the same name must be provided (without HTML5_ prefix)
+        $safeScripting = new HTMLPurifier_HTMLModule_HTML5_SafeScripting();
+        $safeScripting->name = 'SafeScripting';
+        $def->manager->registerModule($safeScripting);
 
         // use fixed implementation of Boolean attributes, instead of a buggy
         // one provided with 4.6.0

--- a/library/HTMLPurifier/HTMLModule/HTML5/SafeScripting.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/SafeScripting.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * A "safe" script module. No inline JS is allowed, and pointed to JS
+ * files must match whitelist.
+ */
+class HTMLPurifier_HTMLModule_HTML5_SafeScripting extends HTMLPurifier_HTMLModule
+{
+    /**
+     * @type string
+     */
+    public $name = 'HTML5_SafeScripting';
+
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        // These definitions are not intrinsically safe: the attribute transforms
+        // are a vital part of ensuring safety.
+
+        $allowed = $config->get('HTML.SafeScripting');
+
+        $scriptContents = new HTMLPurifier_ChildDef_HTML5_Script();
+        $scriptContents->allow_children = false;
+
+        $script = $this->addElement(
+            'script',
+            'Inline',
+            $scriptContents,
+            null,
+            array(
+                'src' => new HTMLPurifier_AttrDef_Enum(array_keys($allowed), true),
+                'type' => new HTMLPurifier_AttrDef_Enum(array(
+                    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript
+                    'text/javascript',
+                )),
+                'async' => new HTMLPurifier_AttrDef_HTML_Bool2(),
+                'defer' => new HTMLPurifier_AttrDef_HTML_Bool2(),
+                'charset' => 'Enum#utf-8',
+            )
+        );
+
+        $script->attr_transform_pre[] = new HTMLPurifier_AttrTransform_HTML5_Script();
+    }
+}

--- a/library/HTMLPurifier/HTMLModule/HTML5/Scripting.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/Scripting.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * HTML5 Scripting
+ *
+ * WARNING: THIS MODULE IS EXTREMELY DANGEROUS AS IT ENABLES INLINE SCRIPTING
+ * INSIDE HTML PURIFIER DOCUMENTS. USE ONLY WITH TRUSTED USER INPUT!!!
+ *
+ * https://www.w3.org/TR/html50/scripting-1.html
+ */
+class HTMLPurifier_HTMLModule_HTML5_Scripting extends HTMLPurifier_HTMLModule
+{
+    /**
+     * @type string
+     */
+    public $name = 'HTML5_Scripting';
+
+    /**
+     * @type bool
+     */
+    public $safe = false;
+
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        $noscriptContents = new HTMLPurifier_ChildDef_HTML5_Noscript();
+        $this->addElement('noscript', 'Flow', $noscriptContents, 'Common');
+        $this->addElementToContentSet('noscript', 'Inline');
+
+        $scriptContents = new HTMLPurifier_ChildDef_HTML5_Script();
+        $script = $this->addElement('script', 'Flow', $scriptContents, null, array(
+            'src' => new HTMLPurifier_AttrDef_URI(true),
+            'type' => new HTMLPurifier_AttrDef_Enum(array(
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript
+                'text/javascript',
+            )),
+            'async' => new HTMLPurifier_AttrDef_HTML_Bool2(),
+            'defer' => new HTMLPurifier_AttrDef_HTML_Bool2(),
+            // If present, its value must be an ASCII case-insensitive match for "utf-8"
+            // Deprecated: https://html.spec.whatwg.org/multipage/scripting.html#the-script-element
+            'charset' => 'Enum#utf-8',
+        ));
+        $this->addElementToContentSet('script', 'Inline');
+
+        $script->attr_transform_pre[] = new HTMLPurifier_AttrTransform_HTML5_Script();
+    }
+}

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -3,12 +3,20 @@
 class BaseTestCase extends PHPUnit_Framework_TestCase
 {
     /**
+     * @var HTMLPurifier_HTML5Config
+     */
+    protected $config;
+
+    /**
      * @var array
      */
     private $errors;
 
     protected function setUp()
     {
+        $this->config = HTMLPurifier_HTML5Config::create(null);
+        $this->config->set('Cache.DefinitionImpl', null);
+
         $this->errors = array();
         set_error_handler(array($this, 'errorHandler'), E_USER_NOTICE | E_USER_WARNING);
     }
@@ -20,6 +28,18 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
     public function errorHandler($errno, $message)
     {
         $this->errors[] = compact('errno', 'message');
+    }
+
+    /**
+     * @param string $input
+     * @param string $expect OPTIONAL
+     */
+    public function assertResult($input, $expect = null)
+    {
+        $purifier = new HTMLPurifier($this->config);
+        $output = $purifier->purify($input);
+
+        $this->assertSame($expect !== null ? $expect : $input, $output);
     }
 
     /**

--- a/tests/HTMLPurifier/HTMLModule/HTML5/SafeScriptingTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/SafeScriptingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_SafeScriptingTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->config->set('HTML.SafeScripting', array('https://localhost/foo.js'));
+    }
+
+    public function testMinimal()
+    {
+        $this->assertResult(
+            '<script></script>',
+            ''
+        );
+    }
+
+    public function testGood()
+    {
+        $this->assertResult(
+            '<script type="text/javascript" src="https://localhost/foo.js" async defer charset="utf-8"></script>'
+        );
+    }
+
+    public function testGoodWithAutoclosedTag()
+    {
+        $this->assertResult(
+            '<script type="text/javascript" src="https://localhost/foo.js" async defer charset="utf-8"/>',
+            '<script type="text/javascript" src="https://localhost/foo.js" async defer charset="utf-8"></script>'
+        );
+    }
+
+    public function testBad()
+    {
+        $this->assertResult(
+            '<script type="text/javascript" src="https://localhost/foobar.js" />',
+            ''
+        );
+        $this->assertResult(
+            '<script type="text/javascript" src="https://localhost/FOO.JS" />',
+            ''
+        );
+    }
+
+    public function testBadWithContent()
+    {
+        $this->assertResult(
+            '<script type="text/javascript" src="">Foo</script>',
+            ''
+        );
+        $this->assertResult(
+            '<script type="text/javascript" src="https://localhost/foo.js">Foo</script>',
+            '<script type="text/javascript" src="https://localhost/foo.js"></script>'
+        );
+        $this->assertResult(
+            '<script type="text/javascript" src="https://localhost/foobar.js">Foo</script>',
+            ''
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/ScriptingTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/ScriptingTest.php
@@ -1,0 +1,114 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_ScriptingTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->config->set('HTML.Trusted', true);
+    }
+
+    public function testDefaultRemoval()
+    {
+        $this->config->set('HTML.Trusted', false);
+        $this->assertResult(
+            '<script type="text/javascript">foo();</script>',
+            ''
+        );
+    }
+
+    public function testPreserve()
+    {
+        $this->assertResult(
+            '<script type="text/javascript">foo();</script>'
+        );
+    }
+
+    public function testAllAttributes()
+    {
+        $this->assertResult(
+            '<script defer src="test.js" type="text/javascript" charset="utf-8" async></script>'
+        );
+        $this->assertResult(
+            '<script defer src="" type="text/javascript">PCDATA</script>',
+            '<script defer type="text/javascript">PCDATA</script>'
+        );
+        $this->assertResult(
+            '<script defer src="script.js" type="text/javascript">PCDATA</script>',
+            '<script defer src="script.js" type="text/javascript"></script>'
+        );
+        $this->assertResult(
+            '<p><script>document.write("Foo")</script></p>'
+        );
+        $this->assertResult(
+            '<span><script>document.write("Foo")</script></span>'
+        );
+    }
+
+    public function testUnsupportedAttributes()
+    {
+        $this->assertResult(
+            '<script type="text/javascript" crossorigin="use-credentials">PCDATA</script>',
+            '<script type="text/javascript">PCDATA</script>'
+        );
+    }
+
+    /**
+     * @param string $input
+     * @param string $expectedOutput OPTIONAL
+     * @dataProvider noscriptDataProvider
+     */
+    public function testNoscript($input, $expectedOutput = null)
+    {
+        $this->assertResult($input, $expectedOutput);
+    }
+
+    /**
+     * Data provider for {@link testNoscript()}
+     *
+     * @return array
+     */
+    public function noscriptDataProvider()
+    {
+        return array(
+            'basic' => array(
+                '<noscript>Foo</noscript>',
+            ),
+            'in block element' => array(
+                '<div><noscript>Foo</noscript></div>',
+            ),
+            'in inline element' => array(
+                '<span><noscript>Foo</noscript></span>',
+            ),
+            'nested' => array(
+                '<noscript>Foo<noscript>Bar</noscript>Baz</noscript>',
+                '<noscript>Foo</noscript><noscript>Bar</noscript>Baz',
+            ),
+            'deeply nested' => array(
+                '<noscript>Foo<span><noscript>Bar</noscript></span></noscript>',
+                '<noscript>Foo<span>Bar</span></noscript>',
+            ),
+        );
+    }
+
+    public function testNoscriptInP()
+    {
+        $this->config->autoFinalize = false;
+
+        // PHP DOM parser fails at parsing <noscript> in <p>, which affects
+        // the default HTMLPurifier lexer (DOMLex)
+        $this->assertResult(
+            '<p><noscript>Foo</noscript></p>',
+            '<p></p><noscript>Foo</noscript>'
+        );
+
+        // PH5P lexer properly handles <noscript> in <p> elements
+        $this->config->set('Core.LexerImpl', 'PH5P');
+        $this->assertResult(
+            '<p><noscript>Foo</noscript></p>'
+        );
+
+        $this->config->set('Core.LexerImpl', null);
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/ScriptingTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/ScriptingTest.php
@@ -75,11 +75,18 @@ class HTMLPurifier_HTMLModule_HTML5_ScriptingTest extends BaseTestCase
             'basic' => array(
                 '<noscript>Foo</noscript>',
             ),
+            'empty' => array(
+                '<noscript></noscript>',
+                ''
+            ),
             'in block element' => array(
                 '<div><noscript>Foo</noscript></div>',
             ),
             'in inline element' => array(
                 '<span><noscript>Foo</noscript></span>',
+            ),
+            'with content' => array(
+                '<noscript><h1>Foo</h1><div>Bar</div><p>Baz</p><span>Qux</span></noscript>',
             ),
             'nested' => array(
                 '<noscript>Foo<noscript>Bar</noscript>Baz</noscript>',


### PR DESCRIPTION
This PR adds support for `<script>` HTML5 attributes and sanitization rules.

It resolves #26, but also mitigates ezyang/htmlpurifier#212.