### PR TITLE
Implement HTML5-compliant <iframe> definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ $config->set('HTML.SafeIframe', true);
 $config->set('URI.SafeIframeRegexp', '%^//www\.youtube\.com/embed/%');
 ```
 
+## Configuration
+
+Apart from HTML Purifier's built-in [configuration directives](http://htmlpurifier.org/live/configdoc/plain.html), the following new directives are also supported:
+
+* __HTML.IframeAllowFullscreen__
+
+  Version added: 0.1.11\
+  Type: [Boolean](http://htmlpurifier.org/live/configdoc/plain.html#type-bool)\
+  Default: `false`
+
+  Whether or not to permit `allowfullscreen` attribute on `iframe` tags. It requires either [%HTML.SafeIframe](http://htmlpurifier.org/live/configdoc/plain.html#HTML.SafeIframe) or [%HTML.Trusted](http://htmlpurifier.org/live/configdoc/plain.html#HTML.Trusted) to be enabled.
+
 
 ## Supported HTML5 elements
 

--- a/library/HTMLPurifier/HTML5Config.php
+++ b/library/HTMLPurifier/HTML5Config.php
@@ -2,7 +2,7 @@
 
 class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 {
-    const REVISION = 2019080501;
+    const REVISION = 2019080601;
 
     /**
      * @param  string|array|HTMLPurifier_Config $config
@@ -67,6 +67,10 @@ class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
         if (empty($doctypeConfig->allowed['HTML5'])) {
             $allowed = array_merge($doctypeConfig->allowed, array('HTML5' => true));
             $schema->addAllowedValues('HTML.Doctype', $allowed);
+        }
+
+        if (empty($schema->info['HTML.IframeAllowFullscreen'])) {
+            $schema->add('HTML.IframeAllowFullscreen', false, 'bool', false);
         }
 
         parent::__construct($schema, $parent);

--- a/library/HTMLPurifier/HTML5Definition.php
+++ b/library/HTMLPurifier/HTML5Definition.php
@@ -21,7 +21,7 @@ class HTMLPurifier_HTML5Definition
             // Sorta legacy, but present in strict:
             'Name',
         );
-        $transitional = array('Legacy', 'Target', 'Iframe');
+        $transitional = array('Legacy', 'Target', 'HTML5_Iframe');
         $non_xml = array('NonXMLCommonAttributes');
 
         $def->manager->doctypes->register(
@@ -49,9 +49,6 @@ class HTMLPurifier_HTML5Definition
         $def->manager->attrTypes->set('Float', new HTMLPurifier_AttrDef_Float());
 
         $def->manager->attrTypes->set('Datetime', new HTMLPurifier_AttrDef_HTML5_Datetime());
-
-        // IFRAME
-        $def->addAttribute('iframe', 'allowfullscreen', 'Bool');
 
         return $def;
     }

--- a/library/HTMLPurifier/HTMLModule/HTML5/Iframe.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/Iframe.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * HTML5 compliant replacement for {@link HTMLPurifier_HTMLModule_Iframe}
+ *
+ * This module is not considered safe unless an Iframe whitelisting mechanism
+ * is specified. Currently, the only such mechanism is %URL.SafeIframeRegexp
+ */
+class HTMLPurifier_HTMLModule_HTML5_Iframe extends HTMLPurifier_HTMLModule
+{
+    public $name = 'HTML5_Iframe';
+
+    /**
+     * @type bool
+     */
+    public $safe = false;
+
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        if ($config->get('HTML.SafeIframe')) {
+            $this->safe = true;
+        }
+
+        // HTML Living Standard does not allow content in iframes, whereas W3C
+        // spec does. On the other hand W3C validator follows WHATWG spec.
+        // See:
+        // - https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element
+        // - https://www.w3.org/TR/html52/semantics-embedded-content.html#the-iframe-element
+        // - https://www.w3.org/TR/html50/embedded-content-0.html#the-iframe-element
+
+        // contents must not be 'empty', otherwise <iframe> won't have closing tag
+        $iframeContents = new HTMLPurifier_ChildDef_Empty();
+        $iframeContents->type = 'iframe';
+
+        $iframe = $this->addElement(
+            'iframe',
+            'Inline',
+            $iframeContents,
+            'Common',
+            array(
+                'src'    => 'URI#embedded',
+                'width'  => 'Length',
+                'height' => 'Length',
+                'name'   => 'ID',
+                // other attributes that are present in HTML4 / XHTML spec were
+                // declared as non-conforming, and as such are not included here
+                // https://www.w3.org/TR/2016/WD-html52-20161206/obsolete.html#non-conforming-features
+            )
+        );
+
+        if ($config->get('HTML.Trusted') || (
+            $config->get('HTML.SafeIframe') &&
+            isset($config->def->info['HTML.IframeAllowFullscreen']) && $config->get('HTML.IframeAllowFullscreen')
+        )) {
+            $iframe->attr['allowfullscreen'] = 'Bool#allowfullscreen';
+        }
+    }
+}

--- a/tests/HTMLPurifier/HTML5DefinitionTest.php
+++ b/tests/HTMLPurifier/HTML5DefinitionTest.php
@@ -2,16 +2,6 @@
 
 class HTMLPurifier_HTML5DefinitionBaseTest extends BaseTestCase
 {
-    public function testIframe()
-    {
-        $this->config->set('HTML.SafeIframe', true);
-        $this->config->set('URI.SafeIframeRegexp', '%^(http:|https:)?//(www.youtube(?:-nocookie)?.com/embed/)%');
-
-        $this->assertPurification(
-            '<iframe width="640" height="360" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe>'
-        );
-    }
-
     public function boolAttrInput()
     {
         return array(

--- a/tests/HTMLPurifier/HTMLModule/HTML5/IframeTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/IframeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_IframeTest extends BaseTestCase
+{
+    public function testSafeIframe()
+    {
+        $this->config->set('HTML.SafeIframe', true);
+        $this->config->set('URI.SafeIframeRegexp', '/^foo$/');
+
+        $this->assertPurification(
+            '<iframe width="640" height="360" src="foo"></iframe>'
+        );
+
+        $this->assertPurification(
+            '<iframe width="640" height="360" src="foo" allowfullscreen></iframe>',
+            '<iframe width="640" height="360" src="foo"></iframe>'
+        );
+
+        // Error: Text not allowed in element iframe in this context.
+        // Content model for element iframe: Nothing.
+        $this->assertPurification(
+            '<iframe>Foo</iframe>',
+            '<iframe></iframe>'
+        );
+
+        $this->assertPurification('<h1><iframe></iframe></h1>');
+        $this->assertPurification('<section><iframe></iframe></section>');
+        $this->assertPurification('<div><iframe></iframe></div>');
+        $this->assertPurification('<span><iframe></iframe></span>');
+        $this->assertPurification('<p><iframe></iframe></p>');
+    }
+
+    public function testIframeAllowFullscreen()
+    {
+        $this->config->set('HTML.SafeIframe', true);
+        $this->config->set('URI.SafeIframeRegexp', '/^foo$/');
+        $this->config->set('HTML.IframeAllowFullscreen', true);
+
+        $this->assertPurification('<iframe src="foo" allowfullscreen></iframe>');
+    }
+
+    public function testIframeInTrustedMode()
+    {
+        $this->config->set('HTML.Trusted', true);
+
+        $this->assertPurification(
+            '<iframe width="640" height="360" src="foobar" allowfullscreen></iframe>'
+        );
+    }
+}


### PR DESCRIPTION
Changes from HTML4 / XHTML definition:

- In HTML5 `<iframe>`s have no contents

- HTML5 dropped support for legacy attributes: `frameborder`, `longdesc`, `marginheight`, `marginwidth` and `scrolling`

- `allowfullscreen` attribute is allowed either by enabling `%HTML.Trusted` or by enabling both `%HTML.SafeIframe` and `%HTML.IframeAllowFullscreen`

The last item resolves #38.