### PR TITLE
Implement HTML5-compliant <form> and <blockquote> definitions

### DIFF
--- a/library/HTMLPurifier/HTMLModule/HTML5/Forms.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/Forms.php
@@ -5,7 +5,7 @@
  *
  * This module is marked as safe to support static elements like <progress>
  * out of the box. Only elements inherited from parent module are unsafe,
- * and enabled conditionally with 'HTML.Trusted' config flag.
+ * and enabled conditionally with %HTML.Trusted flag.
  */
 class HTMLPurifier_HTMLModule_HTML5_Forms extends HTMLPurifier_HTMLModule_Forms
 {
@@ -20,6 +20,21 @@ class HTMLPurifier_HTMLModule_HTML5_Forms extends HTMLPurifier_HTMLModule_Forms
     {
         if ($config->get('HTML.Trusted')) {
             parent::setup($config);
+
+            // https://html.spec.whatwg.org/multipage/forms.html#the-form-element
+            $form = $this->addElement(
+                'form',
+                'Form',
+                'Flow',
+                'Common',
+                array(
+                    'accept-charset' => 'Charsets',
+                    'action'  => 'URI',
+                    'method'  => 'Enum#get,post',
+                    'enctype' => 'Enum#application/x-www-form-urlencoded,multipart/form-data,text/plain',
+                )
+            );
+            $form->excludes = array('form' => true);
 
             $this->addElement(
                 'fieldset',

--- a/library/HTMLPurifier/HTMLModule/HTML5/Text.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/Text.php
@@ -60,6 +60,11 @@ class HTMLPurifier_HTMLModule_HTML5_Text extends HTMLPurifier_HTMLModule_Text
         $this->addElement('figure', 'Block', new HTMLPurifier_ChildDef_HTML5_Figure(), 'Common');
         $this->addElement('figcaption', false, 'Flow', 'Common');
 
+        // https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element
+        $this->addElement('blockquote', 'Block', 'Flow', 'Common', array(
+            'cite' => 'URI',
+        ));
+
         // http://developers.whatwg.org/text-level-semantics.html
         $this->addElement('s', 'Inline', 'Inline', 'Common');
         $this->addElement('var', 'Inline', 'Inline', 'Common');

--- a/tests/HTMLPurifier/HTMLModule/HTML5/FormsTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/FormsTest.php
@@ -3,6 +3,45 @@
 class HTMLPurifier_HTMLModule_HTML5_FormsTest extends BaseTestCase
 {
     /**
+     * Data provider for {@link testForm()}
+     * @return array
+     */
+    public function formInput()
+    {
+        return array(
+            array(
+                '<form>Foo</form>',
+            ),
+            array(
+                '<form enctype="text/plain">Foo</form>',
+            ),
+            array(
+                '<form><section><h1>Foo</h1></section></form>',
+            ),
+            array(
+                '<form><nav>Foo</nav></form>'
+            ),
+            array(
+                '<form><form>Foo</form></form>',
+                // DOMLex output
+                '<form></form><form>Foo</form>',
+                // DirectLex outputs '<form></form>'
+            ),
+        );
+    }
+
+    /**
+     * @param string $input
+     * @param string $expected OPTIONAL
+     * @dataProvider formInput
+     */
+    public function testForm($input, $expected = null)
+    {
+        $this->config->set('HTML.Trusted', true);
+        $this->assertPurification($input, $expected);
+    }
+
+    /**
      * @param string $input
      * @param string $expected OPTIONAL
      * @dataProvider fieldsetDataProvider

--- a/tests/HTMLPurifier/HTMLModule/HTML5/TextTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/TextTest.php
@@ -256,6 +256,47 @@ class HTMLPurifier_HTMLModule_HTML5_TextTest extends BaseTestCase
     }
 
     /**
+     * Data provider for {@link testBlockquote()}
+     * @return array
+     */
+    public function blockquoteInput()
+    {
+        return array(
+            array(
+                '<blockquote>Foo</blockquote>',
+            ),
+            array(
+                '<blockquote></blockquote>',
+            ),
+            array(
+                '<blockquote><section>Foo</section></blockquote>',
+            ),
+            array(
+                '<blockquote><nav>Foo</nav></blockquote>',
+            ),
+            array(
+                '<blockquote><h1>Foo</h1></blockquote>',
+            ),
+            array(
+                '<blockquote><p>Foo</p></blockquote>',
+            ),
+            array(
+                '<blockquote><blockquote>Foo</blockquote></blockquote>',
+            ),
+        );
+    }
+
+    /**
+     * @param string $input
+     * @param string $expected OPTIONAL
+     * @dataProvider blockquoteInput
+     */
+    public function testBlockquote($input, $expected = null)
+    {
+        $this->assertPurification($input, $expected);
+    }
+
+    /**
      * Data provider for {@link testAddress()}
      * @return array
      */


### PR DESCRIPTION
Changes:
- `<form>` and `<blockquote>` accepts _Flow content_ as children - which means _Sectioning content_ as well (resolves #44)
- `<form>` no longer supports `accept` attribute - as it's not in [the spec](https://html.spec.whatwg.org/multipage/forms.html#the-form-element)
- `<form>` accepts `text/plain` as allowed value of `enctype` attribute
- `action` attribute of `<form>` is no longer required
