### PR TITLE
Add HTML5 compatible Legacy module

### DIFF
--- a/library/HTMLPurifier/AttrDef/HTML/FontSize.php
+++ b/library/HTMLPurifier/AttrDef/HTML/FontSize.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Validates 'size' attribute of deprecated FONT tag
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/font#attr-size
+ */
+class HTMLPurifier_AttrDef_HTML_FontSize extends HTMLPurifier_AttrDef_CSS_Number
+{
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
+        $string = trim($string);
+
+        switch (substr($string, 0, 1)) {
+            case '+':
+                $sign = 1;
+                break;
+
+            case '-':
+                $sign = -1;
+                break;
+
+            default:
+                $sign = 0;
+                break;
+        }
+
+        if ($sign) {
+            $string = substr($string, 1);
+        }
+
+        if (($string = parent::validate($string, $config, $context)) === false) {
+            return false;
+        }
+
+        // Browsers truncate float 'size' values to integers, so we do the same
+        $value = (int) $string;
+
+        // Size values range from 1 to 7 with 1 being the smallest and 3 the
+        // default. It can be defined using a relative value, like +2 or -3,
+        // which set it relative to the default value.
+        // This means that the relative values are between -2 and +4 (inclusive).
+
+        if ($sign) {
+            $value = max(-2, min(4, $sign * $value));
+            $value = $value >= 0 ? '+' . $value : $value;
+        } else {
+            $value = max(1, min(7, $value));
+        }
+
+        return (string) $value;
+    }
+}

--- a/library/HTMLPurifier/AttrTransform/HTML5/FrameBorder.php
+++ b/library/HTMLPurifier/AttrTransform/HTML5/FrameBorder.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Pre-transform that changes deprecated IFRAME frameborder attribute to CSS.
+ */
+class HTMLPurifier_AttrTransform_HTML5_FrameBorder extends HTMLPurifier_AttrTransform
+{
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr['frameborder'])) {
+            return $attr;
+        }
+
+        $frameBorder = (int) $this->confiscateAttr($attr, 'frameborder');
+
+        if ($frameBorder === 0) {
+            $this->prependCSS($attr, 'border:0;');
+        }
+
+        return $attr;
+    }
+}

--- a/library/HTMLPurifier/HTML5Config.php
+++ b/library/HTMLPurifier/HTML5Config.php
@@ -2,7 +2,7 @@
 
 class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 {
-    const REVISION = 2019080701;
+    const REVISION = 2020053001;
 
     /**
      * @param  string|array|HTMLPurifier_Config $config
@@ -73,6 +73,12 @@ class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
             $schema->add('HTML.IframeAllowFullscreen', false, 'bool', false);
         }
 
+        // HTMLPurifier doesn't define %CSS.DefinitionID, but it's required for
+        // customizing CSS definition object (in the future)
+        if (empty($schema->info['CSS.DefinitionID'])) {
+            $schema->add('CSS.DefinitionID', null, 'string', true);
+        }
+
         parent::__construct($schema, $parent);
 
         $this->set('HTML.Doctype', 'HTML5');
@@ -84,11 +90,10 @@ class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
     {
         // Setting HTML.* keys removes any previously instantiated HTML
         // definition object, so set up HTML5 definition as late as possible
-        $needSetup = $type === 'HTML' && !isset($this->definitions[$type]);
-        if ($needSetup) {
+        if ($type === 'HTML' && empty($this->definitions[$type])) {
             if ($def = parent::getDefinition($type, true, true)) {
                 /** @var HTMLPurifier_HTMLDefinition $def */
-                HTMLPurifier_HTML5Definition::setupDefinition($def);
+                HTMLPurifier_HTML5Definition::setupHTMLDefinition($def, $this);
             }
         }
         return parent::getDefinition($type, $raw, $optimized);

--- a/library/HTMLPurifier/HTML5Definition.php
+++ b/library/HTMLPurifier/HTML5Definition.php
@@ -1,15 +1,16 @@
 <?php
 
-class HTMLPurifier_HTML5Definition
+abstract class HTMLPurifier_HTML5Definition
 {
     /**
      * Adds HTML5 element and attributes to a provided definition object.
      *
      * @param  HTMLPurifier_HTMLDefinition $def
+     * @param  HTMLPurifier_Config $config
      * @return HTMLPurifier_HTMLDefinition
-     * @throws HTMLPurifier_Exception
+     * @internal
      */
-    public static function setupDefinition(HTMLPurifier_HTMLDefinition $def)
+    public static function setupHTMLDefinition(HTMLPurifier_HTMLDefinition $def, HTMLPurifier_Config $config)
     {
         $def->manager->doctypes->register(
             'HTML5',
@@ -24,8 +25,10 @@ class HTMLPurifier_HTML5Definition
                 // Unsafe:
                 'HTML5_Scripting', 'HTML5_Interactive', 'Object', 'HTML5_Forms',
                 'HTML5_Iframe',
+                // Transitional:
+                'HTML5_Legacy',
             ),
-            array('Tidy_Transitional', 'Tidy_Proprietary'),
+            array('Tidy_HTML5'),
             array()
         );
 

--- a/library/HTMLPurifier/HTMLModule/HTML5/Legacy.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/Legacy.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Legacy module defines elements that were obsoleted / deprecated in HTML5
+ * but are still supported by browsers.
+ *
+ * This module requires Tidy module to be enabled to avoid invalid HTML5 output.
+ * It provides definitions for obsolete attributes and elements that have fixes
+ * defined in Tidy_HTML5 module.
+ */
+class HTMLPurifier_HTMLModule_HTML5_Legacy extends HTMLPurifier_HTMLModule
+{
+    /**
+     * @type string
+     */
+    public $name = 'HTML5_Legacy';
+
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        // Setup additional obsolete / deprecated elements
+
+        $this->addElement('center', 'Block', 'Flow', 'Common');
+
+        $this->addElement('dir', 'Block', 'Required: li', 'Common');
+
+        $this->addElement('font', 'Inline', 'Inline', array('Core', 'I18N'), array(
+            'color' => 'Color',
+            'face'  => new HTMLPurifier_AttrDef_CSS_FontFamily(),
+            'size'  => new HTMLPurifier_AttrDef_HTML_FontSize(),
+        ));
+
+        $this->addElement('menu', 'Block', 'Required: li', 'Common');
+
+        $strike = $this->addElement('strike', 'Inline', 'Inline', 'Common');
+        $strike->formatting = true;
+
+        // Setup modifications to old elements
+
+        $align = 'Enum#left,right,center,justify';
+
+        $br = $this->addBlankElement('br');
+        $br->attr['clear'] = 'Enum#all,left,right,none';
+
+        $caption = $this->addBlankElement('caption');
+        $caption->attr['align'] = 'Enum#top,bottom,left,right';
+
+        $div = $this->addBlankElement('div');
+        $div->attr['align'] = $align;
+
+        for ($i = 1; $i <= 6; $i++) {
+            $h = $this->addBlankElement("h$i");
+            $h->attr['align'] = $align;
+        }
+
+        $hr = $this->addBlankElement('hr');
+        $hr->attr['align'] = $align;
+        $hr->attr['noshade'] = 'Bool#noshade';
+        $hr->attr['size'] = 'Pixels';
+        $hr->attr['width'] = 'Length';
+
+        $img = $this->addBlankElement('img');
+        $img->attr['align'] = 'IAlign';
+        $img->attr['border'] = 'Pixels';
+        $img->attr['hspace'] = 'Pixels';
+        $img->attr['vspace'] = 'Pixels';
+
+        $li = $this->addBlankElement('li');
+        $li->attr['value'] = new HTMLPurifier_AttrDef_Integer();
+        $li->attr['type'] = 'Enum#s:1,i,I,a,A,circle,disc,square';
+
+        $p = $this->addBlankElement('p');
+        $p->attr['align'] = $align;
+
+        $pre = $this->addBlankElement('pre');
+        $pre->attr['width'] = 'Number';
+
+        $table = $this->addBlankElement('table');
+        $table->attr['align'] = 'Enum#left,center,right';
+        $table->attr['bgcolor'] = 'Color';
+
+        $tr = $this->addBlankElement('tr');
+        $tr->attr['bgcolor'] = 'Color';
+
+        $th = $this->addBlankElement('th');
+        $th->attr['bgcolor'] = 'Color';
+        $th->attr['height'] = 'Length';
+        $th->attr['nowrap'] = 'Bool#nowrap';
+        $th->attr['width'] = 'Length';
+
+        $td = $this->addBlankElement('td');
+        $td->attr['bgcolor'] = 'Color';
+        $td->attr['height'] = 'Length';
+        $td->attr['nowrap'] = 'Bool#nowrap';
+        $td->attr['width'] = 'Length';
+
+        $ul = $this->addBlankElement('ul');
+        $ul->attr['type'] = 'Enum#circle,disc,square';
+
+        // Setup modifications to "unsafe" elements
+
+        $iframe = $this->addBlankElement('iframe');
+        $iframe->attr['frameborder'] = 'Enum#0,1';
+
+        $input = $this->addBlankElement('input');
+        $input->attr['align'] = 'IAlign';
+
+        $legend = $this->addBlankElement('legend');
+        $legend->attr['align'] = 'LAlign';
+    }
+}

--- a/library/HTMLPurifier/HTMLModule/HTML5/List.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/List.php
@@ -26,5 +26,8 @@ class HTMLPurifier_HTMLModule_HTML5_List extends HTMLPurifier_HTMLModule_List
         // Attributes that were deprecated in HTML4, but reintroduced in HTML5
         $ol->attr['start'] = new HTMLPurifier_AttrDef_Integer();
         $ol->attr['type'] = 'Enum#s:1,a,A,i,I';
+
+        $li = $this->info['li'];
+        $li->attr['value'] = new HTMLPurifier_AttrDef_Integer();
     }
 }

--- a/library/HTMLPurifier/HTMLModule/Tidy/HTML5.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/HTML5.php
@@ -1,0 +1,36 @@
+<?php
+
+class HTMLPurifier_HTMLModule_Tidy_HTML5 extends HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4
+{
+    public $name = 'Tidy_HTML5';
+
+    /**
+     * This is the lenient level. If a tag or attribute is about to be removed
+     * because it isn't supported by the doctype, Tidy will step in and change
+     * into an alternative that is supported.
+     * @var string
+     */
+    public $defaultLevel = 'light';
+
+    /**
+     * @return array
+     */
+    public function makeFixes()
+    {
+        $fixes = parent::makeFixes();
+
+        // Remove transforms for valid HTML5 elements
+        unset(
+            $fixes['u'],
+            $fixes['s'],
+            $fixes['ol@type']
+        );
+
+        $fixes['font'] = new HTMLPurifier_TagTransform_Font2();
+        $fixes['strike'] = new HTMLPurifier_TagTransform_Simple('s');
+
+        $fixes['iframe@frameborder'] = new HTMLPurifier_AttrTransform_HTML5_FrameBorder();
+
+        return $fixes;
+    }
+}

--- a/library/HTMLPurifier/TagTransform/Font2.php
+++ b/library/HTMLPurifier/TagTransform/Font2.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Transforms FONT tags to the proper form (SPAN with CSS styling)
+ *
+ * This is a replacement implementation for {@link HTMLPurifier_TagTransform_Font},
+ * because the original one uses relative font sizes, which should be computed
+ * relative to document (in rem units), and not relative to parent element (percent).
+ *
+ * In the example below both strings have the same font size:
+ * <pre>
+ * <font size="4"><font size="+2">Foo</font></font>
+ * <font size="+2">Foo</font>
+ * </pre>
+ *
+ * Also font-family names other than generic is wrapped in quotes.
+ */
+class HTMLPurifier_TagTransform_Font2 extends HTMLPurifier_TagTransform
+{
+    /**
+     * @type string
+     */
+    public $transform_to = 'span';
+
+    /**
+     * Size conversion values, based on Chrome and Firefox
+     * @var string[]
+     */
+    protected $fontSizes = array(
+        1 => 'xx-small',
+        2 => 'small',
+        3 => 'medium',
+        4 => 'large',
+        5 => 'x-large',
+        6 => 'xx-large',
+        7 => '3rem', // xxx-large is added in CSS 4.0
+    );
+
+    /**
+     * @param HTMLPurifier_Token_Tag $tag
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Token_End|string
+     */
+    public function transform($tag, $config, $context)
+    {
+        if ($tag instanceof HTMLPurifier_Token_End) {
+            $new_tag = clone $tag;
+            $new_tag->name = $this->transform_to;
+            return $new_tag;
+        }
+
+        $attr = $tag->attr;
+        $prepend_style = '';
+
+        if (isset($attr['color'])) {
+            $prepend_style .= 'color:' . $attr['color'] . ';';
+            unset($attr['color']);
+        }
+
+        if (isset($attr['face'])) {
+            $prepend_style .= 'font-family:' . $attr['face'] . ';';
+            unset($attr['face']);
+        }
+
+        if (isset($attr['size'])) {
+            $prepend_style .= $this->transformSize($attr['size']);
+            unset($attr['size']);
+        }
+
+        if ($prepend_style) {
+            $attr['style'] = $prepend_style . (isset($attr['style']) ? $attr['style'] : '');
+        }
+
+        $new_tag = clone $tag;
+        $new_tag->name = $this->transform_to;
+        $new_tag->attr = $attr;
+
+        return $new_tag;
+    }
+
+    /**
+     * @param string $size
+     * @return string
+     */
+    protected function transformSize($size)
+    {
+        $size = trim($size);
+
+        if (!strlen($size)) {
+            return '';
+        }
+
+        $sign = substr($size, 0, 1);
+
+        // values with +/- are computed relative to 3
+        if ($sign === '+') {
+            $value = 3 + (int) substr($size, 1);
+        } elseif ($sign === '-') {
+            $value = 3 - (int) substr($size, 1);
+        } else {
+            $value = (int) $size;
+        }
+
+        // Trim value to range defined in the spec
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/font#attr-size
+        $value = min(7, max(1, $value));
+
+        return 'font-size:' . $this->fontSizes[$value] . ';';
+    }
+}

--- a/tests/HTMLPurifier/AttrDef/HTML/FontSizeTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/FontSizeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+class HTMLPurifier_AttrDef_HTML_FontSizeTest extends AttrDefTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->attr = new HTMLPurifier_AttrDef_HTML_FontSize();
+    }
+
+    public function testValid()
+    {
+        $this->assertValidate('1');
+        $this->assertValidate('7');
+
+        $this->assertValidate('+4');
+        $this->assertValidate('+0');
+        $this->assertValidate('-2');
+
+        $this->assertValidate('1.0', '1');
+        $this->assertValidate('1.9', '1');
+        $this->assertValidate('-1.1', '-1');
+        $this->assertValidate('-1.9', '-1');
+    }
+
+    public function testInvalid()
+    {
+        $this->assertValidate('', false);
+        $this->assertValidate('a', false);
+
+        $this->assertValidate('0', '1');
+        $this->assertValidate('-3', '-2');
+        $this->assertValidate('+5', '+4');
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/LegacyTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/LegacyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_LegacyTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->config->set('HTML.TidyLevel', 'none');
+    }
+
+    public function testCenter()
+    {
+        $this->assertPurification('<center>Foo</center>');
+    }
+
+    public function testFont()
+    {
+        $this->assertPurification('<font>Foo</font>');
+
+        $this->assertPurification('<font size="1" face="Arial">Foo</font>');
+        $this->assertPurification('<font size="7">Foo</font>');
+
+        $this->assertPurification('<font size="+4">Foo</font>');
+        $this->assertPurification('<font size="+0">Foo</font>');
+        $this->assertPurification('<font size="-2">Foo</font>');
+
+        $this->assertPurification('<font size="1.0">Foo</font>', '<font size="1">Foo</font>');
+        $this->assertPurification('<font size="1.9">Foo</font>', '<font size="1">Foo</font>');
+        $this->assertPurification('<font size="-1.1">Foo</font>', '<font size="-1">Foo</font>');
+        $this->assertPurification('<font size="-1.9">Foo</font>', '<font size="-1">Foo</font>');
+
+        $this->assertPurification('<font size="">Foo</font>', '<font>Foo</font>');
+        $this->assertPurification('<font size="a">Foo</font>', '<font>Foo</font>');
+    }
+
+    public function testStrike()
+    {
+        $this->assertPurification('<strike>Foo</strike>');
+    }
+
+    public function testDir()
+    {
+        $this->assertPurification('<dir><li>Foo</li></dir>');
+    }
+
+    public function testMenu()
+    {
+        $this->assertPurification('<menu><li>Foo</li></menu>');
+    }
+
+    public function testOl()
+    {
+        $this->assertPurification('<ol type="circle"><li>Foo</li></ol>', '<ol><li>Foo</li></ol>');
+    }
+
+    public function testUl()
+    {
+        $this->assertPurification('<ul type="circle"><li>Foo</li></ul>');
+    }
+
+    public function testLi()
+    {
+        $this->assertPurification('<ul><li value="-2" type="circle">Foo</li></ul>');
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/ListTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/ListTest.php
@@ -23,4 +23,10 @@ class HTMLPurifier_HTMLModule_HTML5_ListTest extends BaseTestCase
             ),
         );
     }
+
+    public function testLi()
+    {
+        $this->assertPurification('<ul><li value="2">Foo</li></ul>');
+        $this->assertPurification('<ul><li value="-2">Foo</li></ul>');
+    }
 }

--- a/tests/HTMLPurifier/HTMLModule/Tidy/HTML5Test.php
+++ b/tests/HTMLPurifier/HTMLModule/Tidy/HTML5Test.php
@@ -1,0 +1,109 @@
+<?php
+
+class HTMLPurifier_HTMLModule_Tidy_HTML5Test extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->config->set('HTML.TidyLevel', 'light');
+    }
+
+    public function testUnchanged()
+    {
+        $this->assertPurification('<b>Foo</b>');
+        $this->assertPurification('<i>Foo</i>');
+        $this->assertPurification('<s>Foo</s>');
+        $this->assertPurification('<u>Foo</u>');
+    }
+
+    public function testCenter()
+    {
+        $this->assertPurification(
+            '<center>Foo</center>',
+            '<div style="text-align:center;">Foo</div>'
+        );
+    }
+
+    public function testFont()
+    {
+        $this->assertPurification('<font>Foo</font>', '<span>Foo</span>');
+
+        $this->assertPurification(
+            '<font size="1">Foo</font>',
+            '<span style="font-size:xx-small;">Foo</span>'
+        );
+        $this->assertPurification(
+            '<font size="7">Foo</font>',
+            '<span style="font-size:3rem;">Foo</span>'
+        );
+
+        $this->assertPurification(
+            '<font size="+4">Foo</font>',
+            '<span style="font-size:3rem;">Foo</span>'
+        );
+        $this->assertPurification(
+            '<font size="+0">Foo</font>',
+            '<span style="font-size:medium;">Foo</span>'
+        );
+
+        $this->assertPurification(
+            '<font face="Open Sans">Foo</font>',
+            '<span style="font-family:\'Open Sans\';">Foo</span>'
+        );
+    }
+
+    public function testStrike()
+    {
+        $this->assertPurification('<strike>Foo</strike>', '<s>Foo</s>');
+    }
+
+    public function testDir()
+    {
+        $this->assertPurification('<dir><li>Foo</li></dir>', '<ul><li>Foo</li></ul>');
+    }
+
+    public function testMenu()
+    {
+        $this->assertPurification('<menu><li>Foo</li></menu>', '<ul><li>Foo</li></ul>');
+    }
+
+    public function testOl()
+    {
+        $this->assertPurification(
+            '<ol type="circle"><li>Foo</li></ol>',
+            '<ol><li>Foo</li></ol>'
+        );
+    }
+
+    public function testUl()
+    {
+        $this->assertPurification(
+            '<ul type="circle"><li>Foo</li></ul>',
+            '<ul style="list-style-type:circle;"><li>Foo</li></ul>'
+        );
+    }
+
+    public function testLi()
+    {
+        $this->assertPurification(
+            '<ul><li value="-2" type="circle">Foo</li></ul>',
+            '<ul><li value="-2" style="list-style-type:circle;">Foo</li></ul>'
+        );
+    }
+
+    public function testIframe()
+    {
+        $this->config->set('HTML.SafeIframe', true);
+        $this->config->set('URI.SafeIframeRegexp', '/^foo$/');
+
+        $this->assertPurification(
+            '<iframe width="640" height="360" src="foo" frameborder="0"></iframe>',
+            '<iframe width="640" height="360" src="foo" style="border:0;"></iframe>'
+        );
+
+        $this->assertPurification(
+            '<iframe width="640" height="360" src="foo" frameborder="1"></iframe>',
+            '<iframe width="640" height="360" src="foo"></iframe>'
+        );
+    }
+}

--- a/tests/HTMLPurifier/TagTransform/Font2Test.php
+++ b/tests/HTMLPurifier/TagTransform/Font2Test.php
@@ -1,0 +1,79 @@
+<?php
+
+class HTMLPurifier_TagTransform_Font2Test extends BaseTestCase
+{
+    /**
+     * @var HTMLPurifier_Context
+     */
+    protected $context;
+
+    /**
+     * @var HTMLPurifier_TagTransform
+     */
+    protected $transform;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->context = new HTMLPurifier_Context();
+        $this->transform = new HTMLPurifier_TagTransform_Font2();
+    }
+
+    public function testTransform()
+    {
+        $tag = new HTMLPurifier_Token_Start('font', array(
+            'color' => '#000',
+            'face'  => 'monospace',
+            'size'  => '7',
+        ));
+
+        $result = $this->transform->transform($tag, $this->config, $this->context);
+
+        $this->assertEquals('span', $result->name);
+        $this->assertEquals(array(
+            'style' => "color:#000;font-family:monospace;font-size:3rem;",
+        ), $result->attr);
+    }
+
+    public function testSizePlus()
+    {
+        $tag = new HTMLPurifier_Token_Start('font', array(
+            'color' => '#666',
+            'face'  => 'sans-serif',
+            'size'  => '+4',
+        ));
+
+        $result = $this->transform->transform($tag, $this->config, $this->context);
+
+        $this->assertEquals('span', $result->name);
+        $this->assertEquals(array(
+            'style' => "color:#666;font-family:sans-serif;font-size:3rem;",
+        ), $result->attr);
+    }
+
+    public function testSizeMinus()
+    {
+        $tag = new HTMLPurifier_Token_Start('font', array(
+            'color' => '#666',
+            'face'  => 'sans-serif',
+            'size'  => '-2',
+        ));
+
+        $result = $this->transform->transform($tag, $this->config, $this->context);
+
+        $this->assertEquals('span', $result->name);
+        $this->assertEquals(array(
+            'style' => "color:#666;font-family:sans-serif;font-size:xx-small;",
+        ), $result->attr);
+    }
+
+    public function testSizeEmpty()
+    {
+        $tag = new HTMLPurifier_Token_Start('font', array('size' => ''));
+
+        $result = $this->transform->transform($tag, $this->config, $this->context);
+        $this->assertEquals('span', $result->name);
+        $this->assertEquals(array(), $result->attr);
+    }
+}


### PR DESCRIPTION
`Legacy` and `Tidy_Transitional` modules provided by HTMLPurifier are not compatible with HTML5 elements. For example, `<s>` tag is not obsolete in HTML5, so it shouldn't be transformed to `<span>`. The same applies to `<u>` tag.

Also the definition of `<font>` element in HTMLPurifier's Legacy module is missing validation of `size` and `face` attributes. And it's transform to `<span>` provides invalid `font-size` values for relative values of the `size` attribute.