### PR TITLE
Set up RemoveEmpty strategy to not remove <video> and <audio> elements

### DIFF
--- a/library/HTMLPurifier/HTML5Config.php
+++ b/library/HTMLPurifier/HTML5Config.php
@@ -85,6 +85,18 @@ class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 
         parent::__construct($schema, $parent);
 
+        // Set up defaults for AutoFormat.RemoveEmpty.Predicate to properly handle
+        // empty video and audio elements.
+        if (!$this->plist->has('AutoFormat.RemoveEmpty.Predicate')) {
+            $this->set('AutoFormat.RemoveEmpty.Predicate', array_merge(
+                $schema->defaults['AutoFormat.RemoveEmpty.Predicate'],
+                array(
+                    'video' => array(),
+                    'audio' => array(),
+                )
+            ));
+        }
+
         $this->set('HTML.Doctype', 'HTML5');
         $this->set('HTML.XHTML', false);
         $this->set('Attr.ID.HTML5', true);

--- a/tests/HTMLPurifier/HTMLModule/HTML5/MediaTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/MediaTest.php
@@ -151,4 +151,17 @@ class HTMLPurifier_HTMLModule_HTML5_MediaTest extends BaseTestCase
             ),
         );
     }
+
+    public function testRemoveEmpty()
+    {
+        $this->config->set('AutoFormat.RemoveEmpty', true);
+
+        $this->assertPurification('<video src="video.mp4"></video>');
+        $this->assertPurification('<video><source src="video.ogv" type="video/ogg"></video>');
+
+        $this->assertPurification('<audio src="audio.mp3"></audio>');
+        $this->assertPurification('<audio><source src="audio.ogg" type="audio/ogg"></audio>');
+
+        $this->assertPurification('<img src="image.jpg" alt="">');
+    }
 }


### PR DESCRIPTION
Resolves issue #64.

This PR provides default value for `AutoFormat.RemoveEmpty.Predicate`, so that childless `<video>` and `<audio>` elements are not removed.