### PR TITLE
Add HTML5 spec compliant <caption> definition (#73)

### DIFF
--- a/library/HTMLPurifier/HTML5Config.php
+++ b/library/HTMLPurifier/HTML5Config.php
@@ -2,7 +2,7 @@
 
 class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 {
-    const REVISION = 2021091901;
+    const REVISION = 2022080501;
 
     /**
      * @param  string|array|HTMLPurifier_Config $config

--- a/library/HTMLPurifier/HTMLModule/HTML5/Tables.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/Tables.php
@@ -17,7 +17,9 @@ class HTMLPurifier_HTMLModule_HTML5_Tables extends HTMLPurifier_HTMLModule
      */
     public function setup($config)
     {
-        $this->addElement('caption', false, 'Inline', 'Common');
+        // https://html.spec.whatwg.org/multipage/tables.html#the-caption-element
+        $caption = $this->addElement('caption', false, 'Flow', 'Common');
+        $caption->excludes = $this->makeLookup('table');
 
         $this->addElement('table', 'Block', new HTMLPurifier_ChildDef_HTML5_Table(), 'Common');
 

--- a/tests/HTMLPurifier/HTMLModule/HTML5/TablesTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/TablesTest.php
@@ -6,6 +6,14 @@ class HTMLPurifier_HTMLModule_HTML5_TablesTest extends HTMLPurifier_HTMLModule_H
     {
         return array(
             array('<table></table>'),
+            array('<table><caption><h3>foo</h3><p>bar<p>baz</caption></table>', '<table><caption><h3>foo</h3><p>bar</p><p>baz</p></caption></table>'),
+            array('<table><caption><h3>foo</h3></caption></table>'),
+            array('<table><caption><p>foo<p>bar</caption></table>', '<table><caption><p>foo</p><p>bar</p></caption></table>'),
+            array('<table><caption>foo</caption></table>'),
+            array('<table><caption>foo</table>', '<table><caption>foo</caption></table>'),
+            array('<table><caption>foo </table>', '<table><caption>foo </caption></table>'),
+            array('<table><caption><div>foo<table></table>bar</div> baz</caption></table>', '<table><caption><div>foobar</div> baz</caption></table>'),
+            array('<table><tbody><tr><th>foo</th></tr></tbody><caption>foo</caption></table>', '<table><caption>foo</caption><tbody><tr><th>foo</th></tr></tbody></table>'),
             array('<table><thead><tr><th>foo</th></tr></thead></table>'),
             array('<table><tr><th>foo</th></tr></table>'),
             array('<table><tbody><tr><th>foo</th></tr></tbody></table>'),


### PR DESCRIPTION
Fixes #73 

HTML5 `caption` content model should allow `Flow` content - https://html.spec.whatwg.org/multipage/tables.html#the-caption-element. 
Whereas HTML 4.01 only allowed `Inline` content - https://www.w3.org/TR/html401/struct/tables.html#edef-CAPTION

Updated the definition accordingly.