### PR TITLE
Implement %Attr.AllowedInputTypes config directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ $config->set('URI.SafeIframeRegexp', '%^//www\.youtube\.com/embed/%');
 
 Apart from HTML Purifier's built-in [configuration directives](http://htmlpurifier.org/live/configdoc/plain.html), the following new directives are also supported:
 
+* __Attr.AllowedInputTypes__
+
+  Version added: 0.1.12\
+  Type: [Lookup](http://htmlpurifier.org/live/configdoc/plain.html#type-lookup)\
+  Default: `null`
+
+  List of allowed input types, chosen from the types defined in the spec. By default, the setting is `null`, meaning there is no restriction on allowed types. Empty array means that no input types are allowed, effectively removing `input` elements from the purified output.
+
 * __HTML.Forms__
 
   Version added: 0.1.12\

--- a/library/HTMLPurifier/AttrDef/HTML5/InputType.php
+++ b/library/HTMLPurifier/AttrDef/HTML5/InputType.php
@@ -1,0 +1,47 @@
+<?php
+
+class HTMLPurifier_AttrDef_HTML5_InputType extends HTMLPurifier_AttrDef
+{
+    /**
+     * Lookup table for valid values
+     * @var array
+     * @see https://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_extformsmodule
+     */
+    protected static $values = array(
+        'button' => true,
+        'checkbox' => true,
+        'file' => true,
+        'hidden' => true,
+        'image' => true,
+        'password' => true,
+        'radio' => true,
+        'reset' => true,
+        'submit' => true,
+        'text' => true,
+    );
+
+    /**
+     * @return array
+     */
+    public static function values()
+    {
+        return self::$values;
+    }
+
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
+        $value = strtolower($this->parseCDATA($string));
+
+        if (!isset(self::$values[$value])) {
+            return false;
+        }
+
+        return $value;
+    }
+}

--- a/library/HTMLPurifier/AttrTransform/HTML5/Input.php
+++ b/library/HTMLPurifier/AttrTransform/HTML5/Input.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Performs miscellaneous cross attribute validation and filtering for
+ * HTML5 input elements. This is meant to be a post-transform.
+ */
+class HTMLPurifier_AttrTransform_HTML5_Input extends HTMLPurifier_AttrTransform
+{
+    /**
+     * Allowed attributes vs input type lookup
+     * @var array
+     */
+    protected static $attributes = array(
+        'accept' => array(
+            'file' => true,
+        ),
+        'alt' => array(
+            'image' => true,
+        ),
+        'checked' => array(
+            'checkbox' => true,
+            'radio' => true,
+        ),
+        'maxlength' => array(
+            'password' => true,
+            'text' => true,
+        ),
+        'readonly' => array(
+            'password' => true,
+            'text' => true,
+        ),
+        'required' => array(
+            'checkbox' => true,
+            'file' => true,
+            'password' => true,
+            'radio' => true,
+            'text' => true,
+        ),
+        'size' => array(
+            'password' => true,
+            'text' => true,
+        ),
+        'src' => array(
+            'image' => true,
+        ),
+        'value' => array(
+            'button' => true,
+            'checkbox' => true,
+            'hidden' => true,
+            'password' => true,
+            'radio' => true,
+            'reset' => true,
+            'submit' => true,
+            'text' => true,
+        ),
+    );
+
+    /**
+     * Lookup for input types allowed in current configuration
+     * @var array
+     */
+    protected $allowedInputTypes;
+
+    protected $allowedInputTypesFromConfig;
+
+    /**
+     * @var HTMLPurifier_AttrDef_HTML5_InputType
+     */
+    protected $inputType;
+
+    public function __construct()
+    {
+        $this->inputType = new HTMLPurifier_AttrDef_HTML5_InputType();
+    }
+
+    protected function setupAllowedInputTypes(HTMLPurifier_Config $config)
+    {
+        $allowedInputTypesFromConfig = isset($config->def->info['Attr.AllowedInputTypes'])
+            ? $config->get('Attr.AllowedInputTypes')
+            : null;
+
+        // Check if current allowedInputTypes value is based on the latest value from config.
+        if ($this->allowedInputTypes !== null && $this->allowedInputTypesFromConfig === $allowedInputTypesFromConfig) {
+            return;
+        }
+
+        if (is_array($allowedInputTypesFromConfig)) {
+            $allowedInputTypes = array_intersect_key(
+                $allowedInputTypesFromConfig,
+                HTMLPurifier_AttrDef_HTML5_InputType::values()
+            );
+        } else {
+            $allowedInputTypes = HTMLPurifier_AttrDef_HTML5_InputType::values();
+        }
+
+        $this->allowedInputTypes = $allowedInputTypes;
+        $this->allowedInputTypesFromConfig = $allowedInputTypesFromConfig;
+    }
+
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array|bool
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (isset($attr['type'])) {
+            $t = $this->inputType->validate($attr['type'], $config, $context);
+        } else {
+            $t = 'text';
+        }
+
+        // If an unrecognized input type is provided, use 'text' value instead
+        // and remove the 'type' attribute
+        if ($t === false) {
+            unset($attr['type']);
+            $t = 'text';
+        }
+
+        // If type doesn't pass %Attr.AllowedInputTypes validation, remove the element
+        // from the output
+        $this->setupAllowedInputTypes($config);
+        if (!isset($this->allowedInputTypes[$t])) {
+            return false;
+        }
+
+        // Remove attributes not allowed for detected input type
+        foreach (self::$attributes as $a => $types) {
+            if (array_key_exists($a, $attr) && !isset($types[$t])) {
+                unset($attr[$a]);
+            }
+        }
+
+        // Non-empty 'alt' attribute is required for 'image' input
+        if ($t === 'image' && !isset($attr['alt'])) {
+            $alt = trim($config->get('Attr.DefaultImageAlt'));
+            if ($alt === '') {
+                $name = isset($attr['name']) ? trim($attr['name']) : '';
+                $alt = $name !== '' ? $name : 'image';
+            }
+            $attr['alt'] = $alt;
+        }
+
+        // The value attribute is always optional, though should be considered
+        // mandatory for checkbox, radio, and hidden.
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-value
+        // Nu Validator diverges from the WHATWG spec, as it defines 'value'
+        // attribute as required, where in fact it is optional, and may be an empty string:
+        // https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
+        if (!isset($attr['value']) && ($t === 'checkbox' || $t === 'radio' || $t === 'hidden')) {
+            $attr['value'] = '';
+        }
+
+        return $attr;
+    }
+}

--- a/library/HTMLPurifier/HTML5Config.php
+++ b/library/HTMLPurifier/HTML5Config.php
@@ -2,7 +2,7 @@
 
 class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 {
-    const REVISION = 2022080501;
+    const REVISION = 2022080601;
 
     /**
      * @param  string|array|HTMLPurifier_Config $config
@@ -90,6 +90,10 @@ class HTMLPurifier_HTML5Config extends HTMLPurifier_Config
 
         if (empty($schema->info['URI.SafeLinkRegexp'])) {
             $schema->add('URI.SafeLinkRegexp', null, 'string', true);
+        }
+
+        if (empty($schema->info['Attr.AllowedInputTypes'])) {
+            $schema->add('Attr.AllowedInputTypes', null, 'lookup', true);
         }
 
         // HTMLPurifier doesn't define %CSS.DefinitionID, but it's required for

--- a/library/HTMLPurifier/HTMLModule/HTML5/Forms.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/Forms.php
@@ -42,5 +42,27 @@ class HTMLPurifier_HTMLModule_HTML5_Forms extends HTMLPurifier_HTMLModule_Forms
             )
         );
         $form->excludes = array('form' => true);
+
+        $input = $this->addElement(
+            'input',
+            'Formctrl',
+            'Empty',
+            'Common',
+            array(
+                'accept' => 'ContentTypes',
+                'accesskey' => 'Character',
+                'alt' => 'Text',
+                'checked' => 'Bool#checked',
+                'disabled' => 'Bool#disabled',
+                'maxlength' => 'Pixels',
+                'name' => 'Text',
+                'readonly' => 'Bool#readonly',
+                'size' => 'Pixels',
+                'src' => 'URI#embedded',
+                'type*' => new HTMLPurifier_AttrDef_HTML5_InputType(),
+                'value' => 'Text',
+            )
+        );
+        $input->attr_transform_post[] = new HTMLPurifier_AttrTransform_HTML5_Input();
     }
 }

--- a/tests/AttrTransformTestCase.php
+++ b/tests/AttrTransformTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+abstract class AttrTransformTestCase extends BaseTestCase
+{
+    /**
+     * @var HTMLPurifier_AttrTransform
+     */
+    protected $transform;
+
+    public function assertResult($input, $expected = null)
+    {
+        if (func_num_args() < 2) {
+            $expected = $input;
+        }
+        $this->assertEquals($expected, $this->transform->transform($input, $this->config, $this->context));
+    }
+}

--- a/tests/HTMLPurifier/AttrDef/HTML5/InputTypeTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML5/InputTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @property HTMLPurifier_AttrDef_HTML5_InputType $attr
+ */
+class HTMLPurifier_AttrDef_HTML5_InputTypeTest extends AttrDefTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->attr = new HTMLPurifier_AttrDef_HTML5_InputType();
+    }
+
+    public function testValidInputType()
+    {
+        $this->assertValidate('text');
+    }
+
+    public function testInvalidInputType()
+    {
+        $this->assertValidate('foo', false);
+    }
+
+    public function testUppercaseInputType()
+    {
+        $this->assertValidate('TEXT', 'text');
+    }
+}

--- a/tests/HTMLPurifier/AttrTransform/HTML5/InputTest.php
+++ b/tests/HTMLPurifier/AttrTransform/HTML5/InputTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * @property HTMLPurifier_AttrTransform_Input $transform
+ */
+class HTMLPurifier_AttrTransform_HTML5_InputTest extends AttrTransformTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->transform = new HTMLPurifier_AttrTransform_HTML5_Input();
+    }
+
+    public function testEmptyInput()
+    {
+        $this->assertResult(array());
+    }
+
+    public function testInvalidCheckedWithEmpty()
+    {
+        $this->assertResult(array('checked' => 'checked'), array());
+    }
+
+    public function testInvalidCheckedWithPassword()
+    {
+        $this->assertResult(array(
+            'checked' => 'checked',
+            'type' => 'password',
+        ), array(
+            'type' => 'password',
+        ));
+    }
+
+    public function testValidCheckedWithUcCheckbox()
+    {
+        $this->assertResult(array(
+            'checked' => 'checked',
+            'type' => 'CHECKBOX',
+            'value' => 'bar',
+        ));
+    }
+
+    public function testInvalidMaxlength()
+    {
+        $this->assertResult(array(
+            'maxlength' => '10',
+            'type' => 'checkbox',
+            'value' => 'foo',
+        ), array(
+            'type' => 'checkbox',
+            'value' => 'foo',
+        ));
+    }
+
+    public function testValidMaxLength()
+    {
+        $this->assertResult(array(
+            'maxlength' => '10',
+        ));
+    }
+
+    public function testSizeWithCheckbox()
+    {
+        $this->assertResult(array(
+            'type' => 'checkbox',
+            'value' => 'foo',
+            'size' => '100',
+        ), array(
+            'type' => 'checkbox',
+            'value' => 'foo',
+        ));
+    }
+
+    public function testSizeWithPassword()
+    {
+        $this->assertResult(array(
+            'type' => 'password',
+            'size' => '100',
+        ));
+    }
+
+    public function testInvalidSrc()
+    {
+        $this->assertResult(array(
+            'src' => 'img.png',
+        ), array());
+    }
+
+    public function testMissingValue()
+    {
+        $this->assertResult(array(
+            'type' => 'checkbox',
+        ), array(
+            'type' => 'checkbox',
+            'value' => '',
+        ));
+    }
+
+    public function testTextInputTypeNotAllowed()
+    {
+        $this->config->set('Attr.AllowedInputTypes', array('password'));
+
+        $this->assertResult(array('type' => 'text'), false);
+        $this->assertResult(array('type' => 'password'));
+    }
+
+    public function testNullAllowedInputTypes()
+    {
+        $this->config->set('Attr.AllowedInputTypes', null);
+
+        $this->assertResult(array('type' => 'text'));
+        $this->assertResult(array('type' => 'password'));
+    }
+
+    public function testEmptyAllowedInputTypes()
+    {
+        $this->config->set('Attr.AllowedInputTypes', array());
+
+        $this->assertResult(array('type' => 'text'), false);
+        $this->assertResult(array('type' => 'password'), false);
+    }
+
+    public function testInvalidAllowedInputTypes()
+    {
+        $this->config->set('Attr.AllowedInputTypes', array('foo'));
+
+        // 'foo' type is converted to 'text', and 'text' type is not allowed
+        $this->assertResult(array('type' => 'foo'), false);
+        $this->assertResult(array('type' => 'text'), false);
+        $this->assertResult(array('type' => 'password'), false);
+    }
+
+    public function testInvalidOrEmptyInputType()
+    {
+        $this->assertResult(array('type' => 'foo'), array());
+        $this->assertResult(array('type' => ''), array());
+        $this->assertResult(array(), array());
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/CommonAttributesTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/CommonAttributesTest.php
@@ -38,6 +38,7 @@ class HTMLPurifier_HTMLModule_HTML5_CommonAttributesTest extends BaseTestCase
 
         $this->config->set('HTML.Trusted', true);
         $this->assertPurification('<button tabindex="1">Foo</button>');
+        $this->assertPurification('<input type="text" tabindex="1">');
     }
 
     public function testInputmode()

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/BaseTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/BaseTest.php
@@ -1,0 +1,11 @@
+<?php
+
+abstract class HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+    extends HTMLPurifier_HTMLModule_HTML5_AbstractTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->config->set('HTML.Forms', true);
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/ButtonTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/ButtonTest.php
@@ -1,0 +1,28 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_ButtonTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input button' => array(
+                '<input type="button" name="foo" value="foo" disabled>',
+            ),
+            // This is where Nu Validator doesn't conform to WHATWG spec, because it
+            // requires a non-empty value attribute to be present, whereas according
+            // to the spec value attribute is optional, and an empty string is
+            // perfectly valid.
+            // "A label for the button must be provided in the value attribute,
+            // though it may be the empty string. If the element has a value attribute,
+            // the button's label must be the value of that attribute"
+            // https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
+            'input button empty value' => array(
+                '<input type="button" name="foo" value="">',
+            ),
+            'input button no value' => array(
+                '<input type="button" name="foo">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/CheckboxTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/CheckboxTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_CheckboxTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input checkbox' => array(
+                '<input type="checkbox" name="foo" value="foo" checked disabled>',
+            ),
+            'input checkbox empty value' => array(
+                '<input type="checkbox" name="foo" value="">',
+            ),
+            'input checkbox no value' => array(
+                '<input type="checkbox" name="foo">',
+                '<input type="checkbox" name="foo" value="">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/FileTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/FileTest.php
@@ -1,0 +1,14 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_FileTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input file' => array(
+                '<input type="file" name="uploads" accept=".jpg, .jpeg, .png, .svg, .gif">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/HiddenTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/HiddenTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_HiddenTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input hidden' => array(
+                '<input type="hidden" name="foo" value="foo" disabled>',
+            ),
+            'input hidden no value attribute' => array(
+                '<input type="hidden">',
+                '<input type="hidden" value="">',
+            ),
+            'input hidden empty value attribute' => array(
+                '<input type="hidden" value="">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/ImageTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/ImageTest.php
@@ -1,0 +1,22 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_ImageTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input image' => array(
+                '<input type="image" alt="foo" src="http://foo.com/foo.png">',
+            ),
+            'input image alt default' => array(
+                '<input type="image">',
+                '<input type="image" alt="image">',
+            ),
+            'input image alt from name' => array(
+                '<input type="image" name="image1">',
+                '<input type="image" name="image1" alt="image1">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/PasswordTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/PasswordTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_PasswordTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input password' => array(
+                '<input type="password" disabled maxlength="64" name="foo" readonly value="foo" size="10">',
+            ),
+            'input password empty value' => array(
+                '<input type="password" value="">',
+            ),
+            'input password no value' => array(
+                '<input type="password">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/RadioTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/RadioTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_RadioTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input radio' => array(
+                '<input type="radio" name="foo" value="foo" checked disabled>',
+            ),
+            'input radio empty value' => array(
+                '<input type="radio" name="foo" value="">',
+            ),
+            'input radio no value' => array(
+                '<input type="radio" name="foo">',
+                '<input type="radio" name="foo" value="">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/ResetTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/ResetTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_ResetTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input reset' => array(
+                '<input type="reset" name="foo" value="foo" disabled>',
+            ),
+            'input reset empty value' => array(
+                '<input type="reset" name="foo" value="">',
+            ),
+            'input reset no value' => array(
+                '<input type="reset" name="foo">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/SubmitTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/SubmitTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_SubmitTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input submit' => array(
+                '<input type="submit" name="foo" value="foo" disabled>',
+            ),
+            'input submit empty value' => array(
+                '<input type="submit" name="foo" value="">',
+            ),
+            'input submit no value' => array(
+                '<input type="submit" name="foo">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/TextTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/Input/TextTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_Input_TextTest
+    extends HTMLPurifier_HTMLModule_HTML5_Forms_BaseTest
+{
+    public function dataProvider()
+    {
+        return array(
+            'input text' => array(
+                '<input type="text" disabled maxlength="64" name="foo" readonly value="foo" size="10">',
+            ),
+            'input text empty value' => array(
+                '<input type="text" value="">',
+            ),
+            'input text no value' => array(
+                '<input type="text">',
+            ),
+        );
+    }
+}

--- a/tests/HTMLPurifier/HTMLModule/HTML5/Forms/InputTest.php
+++ b/tests/HTMLPurifier/HTMLModule/HTML5/Forms/InputTest.php
@@ -1,0 +1,43 @@
+<?php
+
+class HTMLPurifier_HTMLModule_HTML5_Forms_InputTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->config->set('HTML.Forms', true);
+    }
+
+    public function testAllowedInputTypes()
+    {
+        $this->config->autoFinalize = false;
+
+        $this->config->set('Attr.AllowedInputTypes', null);
+        $this->assertPurification('<input type="text">');
+
+        $this->config->set('Attr.AllowedInputTypes', array());
+        $this->assertPurification('<input type="text">', '');
+
+        $this->config->set('Attr.AllowedInputTypes', array('password'));
+        $this->assertPurification(
+            '<input type="text"><input type="password">',
+            '<input type="password">'
+        );
+
+        // input type is obligatory in XHTML1.0
+        // $this->config->set('Attr.AllowedInputTypes', null);
+        // $this->assertPurification(
+        //    '<input><input type="foo">',
+        //    '<input><input>'
+        // );
+
+        $this->config->set('Attr.AllowedInputTypes', array('password'));
+        $this->assertPurification('<input><input type="text">', '');
+    }
+
+    // public function testEmptyType()
+    // {
+    //    $this->assertPurification('<input>');
+    //    $this->assertPurification('<input type="">', '<input>');
+    // }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,4 +31,5 @@ if (getenv('TRAVIS_PHP_VERSION')) {
 
 require_once __DIR__ . '/BaseTestCase.php';
 require_once __DIR__ . '/AttrDefTestCase.php';
+require_once __DIR__ . '/AttrTransformTestCase.php';
 require_once __DIR__ . '/ChildDefTestCase.php';


### PR DESCRIPTION
This is a good starting point for further changes. At the moment only
HTML4/XHTML1.0 input types are supported.