### PR TITLE
Add contenteditable to CommonAttributes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,14 @@ jobs:
             matrix:
                 operating-system: ['ubuntu-latest']
                 php-versions:
-                    - 8.1
+                    - '8.1'
                     - '8.0'
-                    - 7.4
-                    - 7.3
-                    - 7.2
-                    - 7.1
+                    - '7.4'
+                    - '7.3'
+                    - '7.2'
+                    - '7.1'
                     - '7.0'
-                    - 5.6
-                    - 5.5
-                    - 5.4
-                    - 5.3
+                    - '5.6'
 
         steps:
             - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
-        "ezyang/htmlpurifier": "^4.8"
+        "php": ">=5.6",
+        "ezyang/htmlpurifier": "^4.15"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.7",

--- a/library/HTMLPurifier/HTMLModule/HTML5/CommonAttributes.php
+++ b/library/HTMLPurifier/HTMLModule/HTML5/CommonAttributes.php
@@ -16,6 +16,7 @@ class HTMLPurifier_HTMLModule_HTML5_CommonAttributes extends HTMLPurifier_HTMLMo
             'class' => 'Class',
             'id'    => 'ID',
             'title' => 'CDATA',
+            'contenteditable' => 'ContentEditable',
             // tabindex attribute is supported on all elements (global attributes)
             'tabindex' => 'Integer',
             // Final spec for inputmode global attribute has been published on 15 Dec 2017


### PR DESCRIPTION
This copies `CommonAttributes` [changes](https://github.com/ezyang/htmlpurifier/pull/336) in `v4.15.0` from upstream, otherwise `contenteditable="false"` is not considered valid on HTML5 doc types.

It also bumps the requirements to match ezyang/htmlpurifier in v4.15.0