### PR TITLE
Fix PHPUnit version constraints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
             - name: Install dependencies
               run: |
                 echo PHP_VERSION: ${{ env.PHP_VERSION }}
+                composer require --no-update ezyang/htmlpurifier:\<=4.17.0
                 composer install
 
             - name: Run tests
@@ -57,3 +58,4 @@ jobs:
                 if [ -f "build/logs/clover.xml" ] && [ -f "vendor/bin/php-coveralls" ]; then
                   php vendor/bin/php-coveralls -v;
                 fi
+              continue-on-error: true

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ezyang/htmlpurifier": "^4.8"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.7",
+        "phpunit/phpunit": ">=4.7 <10.0",
         "php-coveralls/php-coveralls": "^1.1|^2.1",
         "masterminds/html5": "^2.7"
     },


### PR DESCRIPTION
Also pin max tested version of HTMLPurifier to 4.17.0, because 4.18.0 [removed support](https://github.com/ezyang/htmlpurifier/commit/4828fdf) for conditional comments. 